### PR TITLE
small improvement in error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 CubesDataLog/
 CubesStatusPictures/
+twophase/
 *_backup.txt

--- a/PC_files/Cubotino_GUI.py
+++ b/PC_files/Cubotino_GUI.py
@@ -212,8 +212,8 @@ def read_settings(file):
                             settings.append('large')   # string setting appends 'large' to the list of settings
                 if len(data)==0:                       # case no one setting has been added to the list
                     print("File", file, "does not contain settings")  # print a feedback to the terminal
-    except:                                            # case the tentative did not succeeded
-        print("Something is wrong with file:", file, "or file missed") # print a feedback to the terminal
+    except Exception as ex:                            # case the tentative did not succeeded
+        print("Something is wrong with file:", file, " or file missed:\r\n", ex)  # print a feedback to the terminal
     return settings                                    # returns the list of settings
 ########################################################################################################################
 


### PR DESCRIPTION
As it took me quite some time figuring our that it was not the file format / content was wrong but rather I started the Cubotino_GUI.py from the wrong folder (hence the files were not found)

This as when the file is not found, there is another error wrt `t_srv_pw_range` not being defined. Which let me to search for other errors rather than simply the missing file/starting from another folder.
I guess that it does not get initialized, but did not directly found where you do that for the other variables

```
Something is wrong with file: Cubotino_cam_settings.txt  or file missed:
 [Errno 2] No such file or directory: 'Cubotino_cam_settings.txt'
Traceback (most recent call last):
  File "t:\3d\finn\CUBOTino_base_version\PC_files\Cubotino_GUI.py", line 2157, in <module>
    gui_var_t_srv_pw.set(t_srv_pw_range)
NameError: name 't_srv_pw_range' is not defined. Did you mean: 't_srv_pw_label'?
```